### PR TITLE
[doyto-query-sql] Fix @GroupBy Mapping: map field name to underline-cased when configured

### DIFF
--- a/doyto-query-sql/src/main/java/win/doyto/query/sql/EntityMetadata.java
+++ b/doyto-query-sql/src/main/java/win/doyto/query/sql/EntityMetadata.java
@@ -20,7 +20,6 @@ import lombok.Getter;
 import win.doyto.query.annotation.GroupBy;
 import win.doyto.query.util.ColumnUtil;
 
-import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -66,8 +65,8 @@ public class EntityMetadata {
         String groupBy = "";
 
         groupByColumns = ColumnUtil.filterFields(entityClass, field -> field.isAnnotationPresent(GroupBy.class))
-                                        .map(Field::getName)
-                                        .collect(Collectors.joining(SEPARATOR));
+                                   .map(field -> ColumnUtil.convertColumn(field.getName()))
+                                   .collect(Collectors.joining(SEPARATOR));
         if (!groupByColumns.isEmpty()) {
             groupBy = " GROUP BY " + this.groupByColumns;
         }

--- a/doyto-query-sql/src/test/java/win/doyto/query/sql/EntityMetadataTest.java
+++ b/doyto-query-sql/src/test/java/win/doyto/query/sql/EntityMetadataTest.java
@@ -21,11 +21,13 @@ import lombok.Setter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import win.doyto.query.annotation.GroupBy;
+import win.doyto.query.config.GlobalConfiguration;
 
 import javax.persistence.Entity;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.parallel.ResourceAccessMode.READ;
+import static org.junit.jupiter.api.parallel.ResourceAccessMode.READ_WRITE;
 
 /**
  * EntityMetadataTest
@@ -46,9 +48,21 @@ class EntityMetadataTest {
 
     @ResourceLock(value = "mapCamelCaseToUnderscore", mode = READ)
     @Test
-    void supportGroupByAnnotation() {
+    void supportGroupByAnnotationForUnderscoreColumn() {
         EntityMetadata entityMetadata = new EntityMetadata(ScoreGroupByStudentView.class);
         assertEquals("student_id AS studentId, avg(score) AS avgScore", entityMetadata.getColumnsForSelect());
+        assertEquals(" GROUP BY student_id", entityMetadata.getGroupBySql());
+    }
+
+    @ResourceLock(value = "mapCamelCaseToUnderscore", mode = READ_WRITE)
+    @Test
+    void supportGroupByAnnotationForCamelCaseColumn() {
+        GlobalConfiguration.instance().setMapCamelCaseToUnderscore(false);
+
+        EntityMetadata entityMetadata = new EntityMetadata(ScoreGroupByStudentView.class);
+        assertEquals("studentId, avg(score) AS avgScore", entityMetadata.getColumnsForSelect());
         assertEquals(" GROUP BY studentId", entityMetadata.getGroupBySql());
+
+        GlobalConfiguration.instance().setMapCamelCaseToUnderscore(true);
     }
 }


### PR DESCRIPTION
```java
class EntityMetadataTest {

    @Getter
    @Setter
    @Entity(name = "t_score")
    private static class ScoreGroupByStudentView {
        @GroupBy
        private Long studentId;
        private Double avgScore;
    }

    @ResourceLock(value = "mapCamelCaseToUnderscore", mode = READ)
    @Test
    void supportGroupByAnnotationForUnderscoreColumn() {
        EntityMetadata entityMetadata = new EntityMetadata(ScoreGroupByStudentView.class);
        assertEquals("student_id AS studentId, avg(score) AS avgScore", entityMetadata.getColumnsForSelect());
        assertEquals(" GROUP BY student_id", entityMetadata.getGroupBySql());
    }
}
```